### PR TITLE
Add optional local API backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,18 @@ npm run build
 ```
 
 For more information and support, please contact Base44 support at app@base44.com.
+## Local API
+
+To run the application without the Base44 SDK you can start the included local API server. This server keeps data in `server/data.json` and exposes endpoints that mimic the SDK.
+
+```
+cd server
+npm install
+node index.js
+```
+
+Then start the front‑end with the `VITE_USE_LOCAL_API` environment variable so it uses the local API instead of the SDK:
+
+```
+VITE_USE_LOCAL_API=true npm run dev
+```

--- a/server/data.json
+++ b/server/data.json
@@ -1,0 +1,10 @@
+{
+  "users": [
+    {"id": 1, "email": "admin@example.com", "password": "admin", "full_name": "Admin User", "role": "admin"},
+    {"id": 2, "email": "user@example.com", "password": "password", "full_name": "Regular User", "role": "member"}
+  ],
+  "bookings": [],
+  "payments": [],
+  "passes": [],
+  "spaces": []
+}

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,77 @@
+const express = require('express');
+const cors = require('cors');
+const fs = require('fs');
+const path = require('path');
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+const DATA_PATH = path.join(__dirname, 'data.json');
+let data = { users: [], bookings: [], payments: [], passes: [], spaces: [] };
+
+function loadData() {
+  if (fs.existsSync(DATA_PATH)) {
+    data = JSON.parse(fs.readFileSync(DATA_PATH));
+  }
+}
+
+function saveData() {
+  fs.writeFileSync(DATA_PATH, JSON.stringify(data, null, 2));
+}
+
+loadData();
+
+// Simple auth middleware (mock)
+function auth(req, res, next) {
+  const token = req.headers['authorization'];
+  if (!token) return res.status(401).json({ message: 'Unauthorized' });
+  const user = data.users.find(u => `Bearer ${u.token}` === token);
+  if (!user) return res.status(401).json({ message: 'Unauthorized' });
+  req.user = user;
+  next();
+}
+
+app.post('/auth/login', (req, res) => {
+  const { email, password } = req.body;
+  const user = data.users.find(u => u.email === email && u.password === password);
+  if (!user) return res.status(401).json({ message: 'Invalid credentials' });
+  const token = Math.random().toString(36).slice(2);
+  user.token = token;
+  saveData();
+  res.json({ token });
+});
+
+app.get('/users/me', auth, (req, res) => {
+  const { password, token, ...userData } = req.user;
+  res.json(userData);
+});
+
+app.put('/users/me', auth, (req, res) => {
+  Object.assign(req.user, req.body);
+  saveData();
+  res.json({ success: true });
+});
+
+app.get('/users', auth, (req, res) => {
+  res.json(data.users.map(({ password, token, ...u }) => u));
+});
+
+app.get('/bookings', auth, (req, res) => {
+  res.json(data.bookings.filter(b => b.user_id === req.user.id));
+});
+
+app.get('/payments', auth, (req, res) => {
+  res.json(data.payments.filter(p => p.user_id === req.user.id));
+});
+
+app.get('/passes', auth, (req, res) => {
+  res.json(data.passes.filter(p => p.user_id === req.user.id));
+});
+
+app.get('/spaces', auth, (req, res) => {
+  res.json(data.spaces);
+});
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => console.log(`Local API running on http://localhost:${PORT}`));

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "rocket-room-local-api",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "express": "^4.18.2",
+    "cors": "^2.8.5"
+  }
+}

--- a/src/api/entities.js
+++ b/src/api/entities.js
@@ -1,15 +1,10 @@
 import { base44 } from './base44Client';
+import * as local from './localEntities.js';
 
+const useLocal = import.meta.env?.VITE_USE_LOCAL_API;
 
-export const Pass = base44.entities.Pass;
-
-export const Booking = base44.entities.Booking;
-
-export const Payment = base44.entities.Payment;
-
-export const Space = base44.entities.Space;
-
-
-
-// auth sdk:
-export const User = base44.auth;
+export const Pass = useLocal ? local.Pass : base44.entities.Pass;
+export const Booking = useLocal ? local.Booking : base44.entities.Booking;
+export const Payment = useLocal ? local.Payment : base44.entities.Payment;
+export const Space = useLocal ? local.Space : base44.entities.Space;
+export const User = useLocal ? local.User : base44.auth;

--- a/src/api/localClient.js
+++ b/src/api/localClient.js
@@ -1,0 +1,48 @@
+const API_URL = 'http://localhost:3001';
+
+async function request(endpoint, options = {}) {
+  const token = localStorage.getItem('token');
+  const res = await fetch(`${API_URL}${endpoint}`, {
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(options.headers || {})
+    }
+  });
+  if (!res.ok) throw new Error('API error');
+  return res.json();
+}
+
+export async function login(email, password) {
+  const data = await request('/auth/login', {
+    method: 'POST',
+    body: JSON.stringify({ email, password })
+  });
+  localStorage.setItem('token', data.token);
+  return data;
+}
+
+export async function me() {
+  return request('/users/me');
+}
+
+export async function updateMe(payload) {
+  return request('/users/me', { method: 'PUT', body: JSON.stringify(payload) });
+}
+
+export async function listBookings() {
+  return request('/bookings');
+}
+
+export async function listPayments() {
+  return request('/payments');
+}
+
+export async function listPasses() {
+  return request('/passes');
+}
+
+export async function listSpaces() {
+  return request('/spaces');
+}

--- a/src/api/localEntities.js
+++ b/src/api/localEntities.js
@@ -1,0 +1,49 @@
+import * as api from './localClient.js';
+
+export const User = {
+  async me() {
+    return api.me();
+  },
+  async updateMyUserData(data) {
+    return api.updateMe(data);
+  },
+  async logout() {
+    localStorage.removeItem('token');
+  },
+  async login(email, password) {
+    return api.login(email, password);
+  },
+  async list() {
+    return api.request('/users');
+  }
+};
+
+export const Booking = {
+  async list() {
+    return api.listBookings();
+  },
+  async filter() {
+    return api.listBookings();
+  }
+};
+
+export const Payment = {
+  async list() {
+    return api.listPayments();
+  },
+  async filter() {
+    return api.listPayments();
+  }
+};
+
+export const Pass = {
+  async list() {
+    return api.listPasses();
+  }
+};
+
+export const Space = {
+  async list() {
+    return api.listSpaces();
+  }
+};


### PR DESCRIPTION
## Summary
- add a small Express server under `server/` to mimic Base44 endpoints
- provide client helpers in `src/api/localClient.js`
- expose entity wrappers in `src/api/localEntities.js`
- switch `src/api/entities.js` based on `VITE_USE_LOCAL_API` env variable
- document how to run the local API in README

## Testing
- `npm run lint` *(fails: Cannot find package)*

------
https://chatgpt.com/codex/tasks/task_e_6871d5c9a644832082ad86750d9e1ca0